### PR TITLE
Fixes docker image location paths

### DIFF
--- a/Api/Dockerfile
+++ b/Api/Dockerfile
@@ -1,9 +1,9 @@
 # For more info see: http://aka.ms/VSContainerToolingDockerfiles
-FROM microsoft/aspnetcore:2.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/aspnetcore-build:2.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk AS builder
 ARG BuildConfiguration=Release
 WORKDIR /src
 COPY *.sln ./

--- a/Web/Dockerfile
+++ b/Web/Dockerfile
@@ -1,9 +1,9 @@
 # For more info see: http://aka.ms/VSContainerToolingDockerfiles
-FROM microsoft/aspnetcore:2.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/aspnetcore-build:2.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk AS builder
 ARG BuildConfiguration=Release
 WORKDIR /src
 COPY *.sln ./


### PR DESCRIPTION
previous paths for FROM statements did not resolve correctly. They threw this error:

```
Building web
[+] Building 2.9s (4/4) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                              0.0s
 => => transferring dockerfile: 749B                                                                                                                                                              0.0s 
 => [internal] load .dockerignore                                                                                                                                                                 0.0s 
 => => transferring context: 35B                                                                                                                                                                  0.0s 
 => CANCELED [internal] load metadata for docker.io/dotnet/sdk:2.0                                                                                                                                2.8s 
 => ERROR [internal] load metadata for docker.io/dotnet/aspnet:2.0                                                                                                                                1.9s
------
 > [internal] load metadata for docker.io/dotnet/aspnet:2.0:
------
failed to solve with frontend dockerfile.v0: failed to create LLB definition: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
ERROR: Service 'web' failed to build : Build failed
```